### PR TITLE
Use a precompiled version of the replacements Regexp upon convert

### DIFF
--- a/lib/greeklish_iso843/converter.rb
+++ b/lib/greeklish_iso843/converter.rb
@@ -64,6 +64,8 @@ class GreeklishIso843::Converter
     'ώ' => 'o'
   }.freeze
 
+  REPLACEMENTS_REGEXP = /#{REPLACEMENTS.keys.join('|')}/i.freeze
+
   BLANK_REGEXP = /\A[[:space:]]*\z/.freeze
 
   attr_reader :text
@@ -77,7 +79,7 @@ class GreeklishIso843::Converter
   end
 
   def convert
-    text.gsub(/#{REPLACEMENTS.keys.join('|')}/i) do |match|
+    text.gsub(REPLACEMENTS_REGEXP) do |match|
       match_data = Regexp.last_match
       replacement = REPLACEMENTS[match.downcase]
 


### PR DESCRIPTION
The benchmarking of the original vs the version with the precompiled Regexp shown here:
```ruby
Benchmark.bm do |x|
   times = 10000
   x.report("compiled") do
     times.times { GreeklishIso843::Converter.new("καλημέρα").convert_compiled }
   end

   x.report("original") do
     times.times { GreeklishIso843::Converter.new("καλημέρα").convert }
   end
 end
```
produced the following results:

```bash
       user     system      total        real
    compiled  0.311771   0.000316   0.312087 (  0.316292)
    original  1.108485   0.004633   1.113118 (  1.127099)

```